### PR TITLE
resent cache at reset

### DIFF
--- a/pyrtr/__init__.py
+++ b/pyrtr/__init__.py
@@ -211,6 +211,7 @@ class RTRConnHandler(socketserver.BaseRequestHandler):
     def handle_reset(self):
         dbg(">Reset")
         self.session_id += 1
+        self.server.db.set_serial(0)
         self.send_cacheresponse()
 
         for asn, ipnet, maxlen in self.server.db.get_announcements4(self.serial):


### PR DESCRIPTION
The RTR server must resent all the cache after receiving a "reset query". However, it is not done because the last_serial is not reset before reaching the get_announcements4() method.

Reset last_serial to allow cache resent.

Link: https://www.rfc-editor.org/rfc/rfc8210.html#page-12