### PR TITLE
fix unpack error

### DIFF
--- a/pyrtr/__init__.py
+++ b/pyrtr/__init__.py
@@ -229,6 +229,8 @@ class RTRConnHandler(socketserver.BaseRequestHandler):
     def handle(self):
         while True:
             b = self.request.recv(self.HEADER_LEN, socket.MSG_WAITALL)
+            if len(b) == 0:
+                break
             proto_ver, pdu_type, sess_id, length = self.decode_header(b)
             dbg(f">Header proto_ver={proto_ver} pdu_type={pdu_type} sess_id={sess_id} length={length}")
 


### PR DESCRIPTION
Fix the following unpack error

> Exception occurred during processing of request from ('192.168.1.2', 49730)
> Traceback (most recent call last):
>   File "/usr/lib/python3.9/socketserver.py", line 650, in process_request_thread
>     self.finish_request(request, client_address)
>   File "/usr/lib/python3.9/socketserver.py", line 360, in finish_request
>     self.RequestHandlerClass(request, client_address, self)
>   File "/usr/lib/python3.9/socketserver.py", line 720, in __init__
>     self.handle()
>   File "/home/lscalber/git/frr/tests/topotests/bgp_rpki_topo1/r1/rtrd.py", line 277, in handle
>     proto_ver, pdu_type, sess_id, length = self.decode_header(b)
>   File "/home/lscalber/git/frr/tests/topotests/bgp_rpki_topo1/r1/rtrd.py", line 99, in decode_header
>     return struct.unpack("!BBHI", buf)
> struct.error: unpack requires a buffer of 8 bytes