### PR TITLE
fix pyrtr shutdown and restart

### DIFF
--- a/pyrtr/__init__.py
+++ b/pyrtr/__init__.py
@@ -190,10 +190,13 @@ class RTRConnHandler(socketserver.BaseRequestHandler):
 
     SERIAL_QUERY_TYPE = 1
     SERIAL_QUERY_LEN = 12
-    def handle_serial_query(self, buf: bytes):
+    def handle_serial_query(self, buf: bytes, sess_id: int):
         serial = struct.unpack('!I', buf)[0]
         dbg(f">Serial query: {serial}")
-        self.server.db.set_serial(0)
+        if sess_id:
+            self.server.db.set_serial(serial)
+        else:
+            self.server.db.set_serial(0)
         self.send_cacheresponse()
 
         for asn, ipnet, maxlen in self.server.db.get_announcements4(serial):
@@ -244,7 +247,7 @@ class RTRConnHandler(socketserver.BaseRequestHandler):
             if pdu_type == self.SERIAL_QUERY_TYPE:
                 b = self.request.recv(self.SERIAL_QUERY_LEN - self.HEADER_LEN,
                         socket.MSG_WAITALL)
-                self.handle_serial_query(b)
+                self.handle_serial_query(b, sess_id)
 
             elif pdu_type == self.RESET_TYPE:
                 self.handle_reset()

--- a/pyrtr/__init__.py
+++ b/pyrtr/__init__.py
@@ -238,6 +238,9 @@ class RTRConnHandler(socketserver.BaseRequestHandler):
             proto_ver, pdu_type, sess_id, length = self.decode_header(b)
             dbg(f">Header proto_ver={proto_ver} pdu_type={pdu_type} sess_id={sess_id} length={length}")
 
+            if sess_id:
+                self.session_id = sess_id
+
             if pdu_type == self.SERIAL_QUERY_TYPE:
                 b = self.request.recv(self.SERIAL_QUERY_LEN - self.HEADER_LEN,
                         socket.MSG_WAITALL)


### PR DESCRIPTION
When the server is disconnected, the RPKI client keeps the server information in its cache: including the received prefixes and the previous session ID. When reconnecting, the client sends the previous session ID. It does not expect to receive the prefixes again.

https://www.rfc-editor.org/rfc/rfc8210.html#section-10

```
   If a client loses connectivity to a cache it is using or otherwise
   decides to switch to a new cache, it SHOULD retain the data from the
   previous cache until it has a full set of data from one or more other
   caches.  Note that this may already be true at the point of
   connection loss if the client has connections to more than one cache.
```
https://www.rfc-editor.org/rfc/rfc8210.html#section-5.3

```
   When replying to a Serial Query, the cache MUST return the minimum
   set of changes needed to bring the router into sync with the cache.
```